### PR TITLE
Update manifest.json to manifest_version 3

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -11,9 +11,11 @@ function openLoadClose( linkObj ) {
     });
 }
 
-chrome.contextMenus.create({
-    id: "openloadclose",
-    title: "Open, load, and close",
-    contexts: [ 'link' ]
+chrome.runtime.onInstalled.addListener(() => {
+        chrome.contextMenus.create({
+        id: "openloadclose",
+        title: "Open, load, and close",
+        contexts: [ 'link' ]
+    });
 });
 chrome.contextMenus.onClicked.addListener( openLoadClose );

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,10 +1,10 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Open, Load, Close",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Open a link, wait for it to load, then close it immediately.",
     "permissions": [ "tabs", "contextMenus" ],
     "background": {
-        "scripts": [ "main.js" ]
+        "service_worker": "main.js"
     }
 }


### PR DESCRIPTION
When re-adding this must-have extension to my new MBP, I noticed an error on `chrome://extensions/`:

![image](https://user-images.githubusercontent.com/228780/202167781-b1c41258-5567-44e5-896f-0ee8311ce406.png)

It turns out `manifest_version` 2 will be sunsetted in January 2023:
![image](https://user-images.githubusercontent.com/228780/202167938-30c3247d-cf21-4985-bff5-b88c8460e625.png)


The linked post (<https://developer.chrome.com/blog/mv2-transition/>) isn't particularly helpful, so I used some of the suggestions in [this tutorial](https://blog.shahednasser.com/chrome-extension-tutorial-migrating-to-manifest-v3-from-v2/) to make small manifest changes so it's `"manifest_version": 3`-compliant, and bumped the extension version to `1.1.0`, dd1ec38ee614f23fa862906d4a4b4868ecfb1c4.


Then an anonymous error cropped up that couldn't' be viewed:
![image](https://user-images.githubusercontent.com/228780/202168785-f2ead49e-308f-4588-8d6f-936968660958.png)

Using the [steps listed here](https://github.com/GoogleChrome/developer.chrome.com/issues/2676#issuecomment-1312638768) to view it, it turned out to be a duplicate id error:
![image](https://user-images.githubusercontent.com/228780/202171850-38e73c4a-7358-47c2-ba8a-43296f04d0bd.png)

So the solution was to create the context menu only once `onInstalled` (85b09fab0dad6ce19fdcc2cbe3f34319a668b5cd, hat tip <https://stackoverflow.com/a/64318706>).

